### PR TITLE
Switch to erlef/setup-beam@v1

### DIFF
--- a/.github/scripts/versions.sh
+++ b/.github/scripts/versions.sh
@@ -13,7 +13,8 @@ elixir_versions () {
         sed 's/-.*//' | \
         uniq | \
         sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | \
-        sed -n '/^1.9.0$/,$p' > $destination
+        sed -n '/^1.9.0$/,$p' | \
+        sort -r > $destination
 
     cd ..
     rm -rf elixir
@@ -28,7 +29,8 @@ erlang_versions () {
         sed 's/^OTP-//' | \
         sed 's/-.*//' | \
         uniq | \
-        sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n > $destination
+        sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | \
+        sort -r > $destination
 
     cd ..
     rm -rf otp

--- a/.github/workflows/plts.yml
+++ b/.github/workflows/plts.yml
@@ -17,9 +17,8 @@ jobs:
           echo ::set-output name=erlangversion::$(cat erlang.txt)
         id: versions
       - name: set up elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
-          experimental-otp: true
           elixir-version: ${{ steps.versions.outputs.elixirversion }}
           otp-version: ${{ steps.versions.outputs.erlangversion }}
       - name: install dependencies

--- a/README.md
+++ b/README.md
@@ -1,21 +1,8 @@
 # Plts
 
-**TODO: Add description**
+Generate PLTs for all Elixir/OTP language pairs.
 
-## Installation
+This will be used in Dialyzer to bootstrap the language PLTs.
 
-
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `plts` to your list of dependencies in `mix.exs`:
-
-```elixir
-def deps do
-  [
-    {:plts, "~> 0.1.0"}
-  ]
-end
-```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/plts](https://hexdocs.pm/plts).
+PLTs available in elixirversion-erlangversion pairs, e.g. 1.9.0-22.0
+in both branch and in tagged releases.


### PR DESCRIPTION
The actions/setup-elixir repository is no longer maintained

> Please note: This repository is currently unmaintained by a team of developers at GitHub. It is now maintained by the Erlang Ecosystem Foundation at erlef/setup-elixir. Rather than using actions/setup-elixir, please begin referring to that action in your workflows, instead.

Hopefully this will solve the error that many of the runs are encountering:
https://github.com/asummers/plts/runs/2662763314?check_suite_focus=true
> Error: The process '/home/runner/work/_actions/actions/setup-elixir/v1/dist/install-otp' failed with exit code 8